### PR TITLE
Support Inky Impression

### DIFF
--- a/lib/scenic_driver_inky.ex
+++ b/lib/scenic_driver_inky.ex
@@ -149,14 +149,12 @@ defmodule ScenicDriverInky do
 
   defp process_color(color_value, x, y, color_high, color_low, color_affinity, dithering)
        when is_integer(color_value) do
-    if color_value > color_high do
-      255
-    else
-      if color_value < color_low do
-        0
-      else
-        dither(dithering, color_affinity, x, y)
-      end
+    cond do
+      color_value > color_high -> 255
+      color_value < color_low -> 0
+      color_value > 120 && color_value < 130 -> 128
+      color_value > 159 && color_value < 170 -> 165
+      true -> dither(dithering, color_affinity, x, y)
     end
   end
 
@@ -190,6 +188,11 @@ defmodule ScenicDriverInky do
 
   defp pixel_to_color({0, 0, 0}), do: :black
   defp pixel_to_color({255, 255, 255}), do: :white
+  defp pixel_to_color({0, 128, 0}), do: :green
+  defp pixel_to_color({0, 0, 255}), do: :blue
+  defp pixel_to_color({255, 0, 0}), do: :red
+  defp pixel_to_color({255, 255, 0}), do: :yellow
+  defp pixel_to_color({255, 165, 0}), do: :orange
   defp pixel_to_color(_), do: :accent
 
   defp vp_supervisor(viewport) do

--- a/lib/scenic_driver_inky.ex
+++ b/lib/scenic_driver_inky.ex
@@ -63,7 +63,16 @@ defmodule ScenicDriverInky do
         true -> @default_color_high
       end
 
-    {:ok, inky_pid} = Inky.start_link(type, accent, opts)
+    inky_pid =
+      case type do
+        :impression ->
+          {:ok, pid} = Inky.start_link(type, name: Inky.ScenicDriver)
+          pid
+
+        _ ->
+          {:ok, pid} = Inky.start_link(type, accent, opts)
+          pid
+      end
 
     {width, height} = size
     {:ok, cap} = RpiFbCapture.start_link(width: width, height: height, display: 0)

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule ScenicDriverInky.MixProject do
       {:scenic, "~> 0.9"},
       {:scenic_driver_nerves_rpi, "~> 0.9", targets: @pi_targets},
       {:rpi_fb_capture, "~> 0.1", targets: @pi_targets},
-      {:inky, github: "jasonmj/inky"},
+      {:inky, "~> 1.0.0"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule ScenicDriverInky.MixProject do
       {:scenic, "~> 0.9"},
       {:scenic_driver_nerves_rpi, "~> 0.9", targets: @pi_targets},
       {:rpi_fb_capture, "~> 0.1", targets: @pi_targets},
-      {:inky, "~> 1.0.0"},
+      {:inky, github: "jasonmj/inky"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end


### PR DESCRIPTION
This commit adds support for the Inky Impression. In order to support all 7 colors, I needed to change the `process_color` function to include handling for more variation in color values. Since the capture appears to pull a relative color value, I included a case statement that accounts for the mid-range values associated with green and orange. There's probably a more elegant way to do this and I'm open to suggestions. For now, I'm pretty sure this change preserves all prior functionality while adding support for the Impression. 