### PR TITLE
Warn about centered Scenic driver local config

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,11 @@ config :sample_scenic_inky, :viewport,
 Note: It is important to configure the ScenicLocalDriver because ScenicDriverInky reads from ScenicLocalDriver
 
 For development on host, we recommend just using the glfw driver for scenic (also shown in the sample). It won't give you that sweet lo-fi representation of the Inky though, so be mindful of accidentally using all those colors when you do.
+
+## Troubleshooting
+
+Ensure that you are also running the `Scenic.Driver.Local` (this is included in the examples above).
+And ensure that `Scenic.Driver.Local` isn't running with `scaled: true, centered: true`. If it is
+then the inky display will also end up offset because ScenicDriverInky is reading from the output of
+`Scenic.Driver.Local` (via the framebuffer).
+


### PR DESCRIPTION
I got bit by this because `mix scenic.new` adds `position: [scaled: true, centered: true, orientation: :normal]` which caused all the content in my inky phat ssd1608 to be black because the actual content was pushed 300+ pixels in.